### PR TITLE
fix issue  go mod unable to fetch bazaar dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
-	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
 
 replace gopkg.in/urfave/cli.v1 v1.20.0 => github.com/urfave/cli v1.22.1

--- a/go.sum
+++ b/go.sum
@@ -346,5 +346,3 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
-launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=


### PR DESCRIPTION
It seems to fix the issue https://github.com/vchain-us/vcn/issues/81 simply by removing launchpad.net/gocheck (bzr dependencies) and run `go mod tidy`.

Run `make` after `go mod tidy`:
```
❯ make
go build -ldflags '-s -X github.com/vchain-us/vcn/pkg/meta.version=v0.8.3 -X github.com/vchain-us/vcn/pkg/meta.gitCommit=aaa8969b12579c0c931bcf5acf11e29ecfcd4b77-dirty -X github.com/vchain-us/vcn/pkg/meta.gitBranch=master -X github.com/vchain-us/vcn/pkg/meta.version=v0.8.3-dev' ./cmd/vcn
```

```
❯ ./vcn
vChain CodeNotary - Notarize and authenticate, from code to production

Usage:
  vcn [command]

Available Commands:
  alerts       Manage alerts
  authenticate Authenticate assets against the blockchain
  dashboard    Open https://dashboard.codenotary.io in browser
  help         Help about any command
  info         Display vcn information
  inspect      Return the asset history with low-level information
  list         List your notarized assets
  login        Log in to codenotary.io
  logout       Logout the current user
  notarize     Notarize an asset onto the blockchain
  serve        Start a local API server
  set          Set specific features options
  unsupport    Unsupport an asset
  untrust      Untrust an asset

Flags:
      --config string   config file (default is $HOME/.vcn/config.json)
  -h, --help            help for vcn
  -o, --output string   output format, one of: --output=json|--output=yaml|--output=''
  -S, --silent          silent mode, don't show progress spinner, but it will still output the result
  -v, --version         version for vcn

Use "vcn [command] --help" for more information about a command.

A newer version of vcn is available to download.

Your version: v0.8.3-dev
Latest version: v0.8.3
You can find the latest release at https://github.com/vchain-us/vcn/releases

~/vendor/go/vcn on master !2                                                                                                                                                                                                at 18:03:51
❯
```

We might need to use replace directive `replace launchpad.net/gocheck => gopkg.in/check.v1` if this doesn't work.