### PR TITLE
Replace CircleCI build/test with a Github action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,23 @@
+name: Build and run testsuite
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+jobs:
+  build_test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [1.13, 1.15]
+    container:
+      image: golang:${{ matrix.go }}-stretch
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Build & run tests
+        run: |
+          make TEST_FLAGS="-timeout 60s -coverprofile cover.out -race -v" test

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,4 +1,4 @@
-name: CodeNotary
+name: Verify the authenticity of commits
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vcn  <img align="right" src="https://github.com/vchain-us/vcn/blob/master/docs/img/cn-color.eeadbabe.svg" width="160px"/>
 > **_vChain CodeNotary_**
 
-[![CircleCI](https://circleci.com/gh/vchain-us/vcn.svg?style=shield)](https://circleci.com/gh/vchain-us/vcn)
+[![Build and run testsuite](https://github.com/codenotary/vcn/actions/workflows/build.yaml/badge.svg)](https://github.com/dmacvicar/vcn/actions/workflows/build.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/vchain-us/vcn?style=flat-square)](https://goreportcard.com/report/github.com/vchain-us/vcn)
 [![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/vchain-us/vcn)
 [![Docker pulls](https://img.shields.io/docker/pulls/codenotary/vcn?style=flat-square)](https://hub.docker.com/r/codenotary/vcn)


### PR DESCRIPTION
As we already have two workflows, it reduces the amount of services.

If this is merged, then https://github.com/codenotary/vcn/pull/128 should be closed.