### PR TITLE
Fix blockchain authentication exit status

### DIFF
--- a/pkg/cmd/verify/verify.go
+++ b/pkg/cmd/verify/verify.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/fatih/color"
 

--- a/pkg/cmd/verify/verify.go
+++ b/pkg/cmd/verify/verify.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"strconv"
 
 	"github.com/fatih/color"
 
@@ -449,6 +450,8 @@ func verify(cmd *cobra.Command, a *api.Artifact, keys []string, org string, user
 			meta.StatusUntrusted:   "is untrusted",
 			meta.StatusUnsupported: "is unsupported",
 		}
+
+		viper.Set("exit-code", strconv.Itoa(verification.Status.Int()))
 
 		switch true {
 		case org != "":


### PR DESCRIPTION
When authenticating against the blockchain service, the unsuccessful status code is not set correctly.