### PR TITLE
chore: vcn context ux improvements. closes #134

### DIFF
--- a/pkg/cmd/login/lc_login.go
+++ b/pkg/cmd/login/lc_login.go
@@ -10,7 +10,10 @@ package login
 
 import (
 	"context"
-	"github.com/vchain-us/vcn/internal/errors"
+	"errors"
+	"fmt"
+	"github.com/fatih/color"
+	vcnerr "github.com/vchain-us/vcn/internal/errors"
 	"github.com/vchain-us/vcn/pkg/api"
 	"github.com/vchain-us/vcn/pkg/meta"
 	"github.com/vchain-us/vcn/pkg/store"
@@ -19,6 +22,13 @@ import (
 
 // Execute the login action
 func ExecuteLC(host, port, lcCert, lcApiKey string, skipTlsVerify, lcNoTls bool) error {
+	if store.CNioContext() == true {
+		return errors.New("Already logged on CodeNotary.io blockchain. Please logout first.")
+	}
+
+	color.Set(meta.StyleAffordance())
+	fmt.Println("Logging into CodeNotary Ledger Compliance.")
+	color.Unset()
 
 	if lcApiKey != "" {
 		u, err := api.NewLcUser(lcApiKey, host, port, lcCert, skipTlsVerify, lcNoTls)
@@ -43,7 +53,7 @@ func ExecuteLC(host, port, lcCert, lcApiKey string, skipTlsVerify, lcNoTls bool)
 		}
 	}
 	if lcApiKey == "" {
-		return errors.ErrNoLcApiKeyEnv
+		return vcnerr.ErrNoLcApiKeyEnv
 	}
 	// shouldn't happen
 	return nil

--- a/pkg/cmd/login/lc_login.go
+++ b/pkg/cmd/login/lc_login.go
@@ -23,7 +23,7 @@ import (
 // Execute the login action
 func ExecuteLC(host, port, lcCert, lcApiKey string, skipTlsVerify, lcNoTls bool) error {
 	if store.CNioContext() == true {
-		return errors.New("Already logged on CodeNotary.io blockchain. Please logout first.")
+		return errors.New("Already logged on CodeNotary.io. Please logout first.")
 	}
 
 	color.Set(meta.StyleAffordance())

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -9,6 +9,7 @@
 package login
 
 import (
+	"errors"
 	"fmt"
 	"github.com/fatih/color"
 	"github.com/spf13/viper"
@@ -40,8 +41,8 @@ func NewCommand() *cobra.Command {
 			return nil
 		},
 		Use:   "login",
-		Short: "Log in to codenotary.io or CodeNotary Ledger Compliance",
-		Long: `Log in to codenotary.io or CodeNotary Ledger Compliance.
+		Short: "Log in to CodeNotary.io or CodeNotary Ledger Compliance",
+		Long: `Log in to CodeNotary.io or CodeNotary Ledger Compliance.
 
 Environment variables:
 VCN_USER=
@@ -112,6 +113,14 @@ VCN_LC_API_KEY=
 
 // Execute the login action
 func Execute() error {
+
+	if store.CNLCContext() == true {
+		return errors.New("Already logged on CodeNotary Ledger Compliance. Please logout first.")
+	}
+
+	color.Set(meta.StyleAffordance())
+	fmt.Println("Logging into CodeNotary.io blockchain.")
+	color.Unset()
 
 	cfg := store.Config()
 

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -119,7 +119,7 @@ func Execute() error {
 	}
 
 	color.Set(meta.StyleAffordance())
-	fmt.Println("Logging into CodeNotary.io blockchain.")
+	fmt.Println("Logging into CodeNotary.io.")
 	color.Unset()
 
 	cfg := store.Config()

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -200,3 +200,13 @@ func (c *ConfigRoot) ClearContext() {
 	}
 	c.CurrentContext = CurrentContext{}
 }
+
+func CNLCContext() bool {
+	cfg := Config()
+	return cfg.CurrentContext.LcHost != ""
+}
+
+func CNioContext() bool {
+	cfg := Config()
+	return cfg.CurrentContext.Email != ""
+}


### PR DESCRIPTION
This add clear messages to the current login flow in order to understand on what services user is logging on.

```
vcn login
Logging into CodeNotary.io blockchain.
Email address: *****@gmail.com
Login password: .
One time password (press enter if null): 
Login successful.
```

```
vcn login --lc-port 3324 --lc-host 127.0.0.1 --lc-no-tls
Error: Already logged on CodeNotary.io blockchain. Please logout first.
```

```
vcn login --lc-port 3324 --lc-host 127.0.0.1 --lc-no-tls
Logging into CodeNotary Ledger Compliance.
Login successful.
```

```
vcn login
Error: Already logged on CodeNotary Ledger Compliance. Please logout first.
```