### PR TITLE
Add --lc-ledger flag for authenticate and inspect commands when used with cross-ledgers API keys

### DIFF
--- a/docs/vcn-cnlc-jumpstart.md
+++ b/docs/vcn-cnlc-jumpstart.md
@@ -309,6 +309,21 @@ It's possible to filter results by signer identifier:
 vcn inspect document.pdf --signerID CygBE_zb8XnprkkO6ncIrbbwYoUq5T1zfyEF6DhqcAI=
 ```
 
+#### Using Cross-Ledgers API Keys
+
+When using Ledger Compliance server, it is possible to use API keys that are not
+specific to one ledger. This kind of keys is supported only by the `authenticate`
+and `inspect` sub-commands. If such an API key is used, the ledger must be explicitly
+specified:
+
+```shell script
+vcn authenticate --signerID <signer-id> --lc-ledger <ledger-name>
+vcn inspect --signerID <signer-id> --lc-ledger <ledger-name>
+```
+
+Alternatively, for using `vcn` in non-interactive mode, the user can supply the API
+Key via the `VCN_LC_LEDGER` environment variable.
+
 ### Local API server
 
 Local API server is supported.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/caarlos0/spin v1.1.0
 	github.com/cespare/cp v1.1.1 // indirect
 	github.com/cmars/basen v0.0.0-20150613233007-fe3947df716e // indirect
-	github.com/codenotary/immudb v0.9.2-0.20210311132031-0714110a5092
+	github.com/codenotary/immudb v0.9.2-0.20210324115202-e54bda6e1cc3
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/dghubble/sling v1.3.0
 	github.com/dustin/go-humanize v1.0.0
@@ -57,7 +57,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564
 	github.com/tyler-smith/go-bip39 v1.0.2
-	github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210324153127-568e37041bef
+	github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210401150401-454ef282b16a
 	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/codenotary/immudb v0.9.2-0.20210210174910-dc27e4a6729f/go.mod h1:jayc
 github.com/codenotary/immudb v0.9.2-0.20210308222937-bff247b03f9b/go.mod h1:jaycynQMhlxXjM6at6dtm6U1YLCbK1m6qdINwfxV++k=
 github.com/codenotary/immudb v0.9.2-0.20210311132031-0714110a5092 h1:lUOzqFmVz1Aha38yzEVVVGggxT+psD4WETDZtl6HpWk=
 github.com/codenotary/immudb v0.9.2-0.20210311132031-0714110a5092/go.mod h1:2riWInwrg8tiL6aLr4PNRQIQ+YTN3HloMmfPnl5DaoM=
+github.com/codenotary/immudb v0.9.2-0.20210324115202-e54bda6e1cc3 h1:ttRb7HzWF5Na8NSA1Mrt0Zj1UzBV7uJo/nuqtuct/lE=
+github.com/codenotary/immudb v0.9.2-0.20210324115202-e54bda6e1cc3/go.mod h1:Bb96jot0qKMMMXWkTwgexImbBVfXpL3abmNtXmQLq/o=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -438,6 +440,8 @@ github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210317171900-7eabf4fbfe22 h
 github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210317171900-7eabf4fbfe22/go.mod h1:JSZUnkw1WnoUMPO0rDJksWiBd/zGixBw1FttXkEH34s=
 github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210324153127-568e37041bef h1:RXj6JDTuBMH3hmYbOHEia6YkqLpr9wqHNqgENk6pd5Y=
 github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210324153127-568e37041bef/go.mod h1:JSZUnkw1WnoUMPO0rDJksWiBd/zGixBw1FttXkEH34s=
+github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210401150401-454ef282b16a h1:SECrnb9kNvMy30Pt0P5A5izBkjRm4wNdLGcRME4vR50=
+github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210401150401-454ef282b16a/go.mod h1:s5+lEX16X8G8oAiUSuesBSvLx6zijhPU7I8BXHRDPlk=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/api/lc_user.go
+++ b/pkg/api/lc_user.go
@@ -11,10 +11,12 @@ package api
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	sdk "github.com/vchain-us/ledger-compliance-go/grpcclient"
-	"github.com/vchain-us/vcn/pkg/store"
 	"strconv"
 	"strings"
+
+	sdk "github.com/vchain-us/ledger-compliance-go/grpcclient"
+	"github.com/vchain-us/vcn/pkg/meta"
+	"github.com/vchain-us/vcn/pkg/store"
 )
 
 // User represent a CodeNotary platform user.
@@ -23,8 +25,8 @@ type LcUser struct {
 }
 
 // NewUser returns a new User instance for the given email.
-func NewLcUser(lcApiKey, host, port, lcCert string, skipTlsVerify bool, noTls bool) (*LcUser, error) {
-	client, err := NewLcClient(lcApiKey, host, port, lcCert, skipTlsVerify, noTls)
+func NewLcUser(lcApiKey, lcLedger, host, port, lcCert string, skipTlsVerify bool, noTls bool) (*LcUser, error) {
+	client, err := NewLcClient(lcApiKey, lcLedger, host, port, lcCert, skipTlsVerify, noTls)
 	if err != nil {
 		return nil, err
 	}
@@ -36,10 +38,10 @@ func NewLcUser(lcApiKey, host, port, lcCert string, skipTlsVerify bool, noTls bo
 }
 
 // NewLcUserVolatile returns a new User instance without a backing cfg file.
-func NewLcUserVolatile(lcApiKey string, host string, port string) *LcUser {
+func NewLcUserVolatile(lcApiKey, lcLedger string, host string, port string) *LcUser {
 	p, _ := strconv.Atoi(port)
 	return &LcUser{
-		Client: sdk.NewLcClient(sdk.ApiKey(lcApiKey), sdk.Host(host), sdk.Port(p), sdk.Dir(store.CurrentConfigFilePath())),
+		Client: sdk.NewLcClient(sdk.ApiKey(lcApiKey), sdk.MetadataPairs([]string{meta.VcnLCLedgerHeaderName, lcLedger}), sdk.Host(host), sdk.Port(p), sdk.Dir(store.CurrentConfigFilePath())),
 	}
 }
 

--- a/pkg/api/user_service.go
+++ b/pkg/api/user_service.go
@@ -14,7 +14,7 @@ import (
 )
 
 // GetUserFromContext returns a new the correct user based on the context
-func GetUserFromContext(context store.CurrentContext, lcApiKey string) (interface{}, error) {
+func GetUserFromContext(context store.CurrentContext, lcApiKey string, lcLedger string) (interface{}, error) {
 
 	if context.Email != "" {
 		return &User{
@@ -25,7 +25,7 @@ func GetUserFromContext(context store.CurrentContext, lcApiKey string) (interfac
 		if lcApiKey == "" {
 			return nil, errors.ErrNoLcApiKeyEnv
 		}
-		client, err := NewLcClientByContext(context, lcApiKey)
+		client, err := NewLcClientByContext(context, lcApiKey, lcLedger)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/inspect/inspect.go
+++ b/pkg/cmd/inspect/inspect.go
@@ -10,10 +10,11 @@ package inspect
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/spf13/viper"
 	"github.com/vchain-us/vcn/internal/assert"
 	"github.com/vchain-us/vcn/pkg/meta"
-	"strings"
 
 	"github.com/vchain-us/vcn/pkg/cmd/internal/cli"
 
@@ -46,6 +47,7 @@ VCN_LC_CERT=
 VCN_LC_SKIP_TLS_VERIFY=false
 VCN_LC_NO_TLS=false
 VCN_LC_API_KEY=
+VCN_LC_LEDGER=
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return viper.BindPFlags(cmd.Flags())
@@ -95,6 +97,7 @@ vcn inspect document.pdf --signerID CygBE_zb8XnprkkO6ncIrbbwYoUq5T1zfyEF6DhqcAI=
 	cmd.Flags().Bool("lc-skip-tls-verify", false, meta.VcnLcSkipTlsVerifyDesc)
 	cmd.Flags().Bool("lc-no-tls", false, meta.VcnLcNoTlsDesc)
 	cmd.Flags().String("lc-api-key", "", meta.VcnLcApiKeyDesc)
+	cmd.Flags().String("lc-ledger", "", meta.VcnLcLedgerDesc)
 
 	cmd.Flags().String("signerID", "", "specify a signerID to refine inspection result on ledger compliance")
 
@@ -152,10 +155,11 @@ func runInspect(cmd *cobra.Command, args []string) error {
 	skipTlsVerify := viper.GetBool("lc-skip-tls-verify")
 	noTls := viper.GetBool("lc-no-tls")
 	lcApiKey := viper.GetString("lc-api-key")
+	lcLedger := viper.GetString("lc-ledger")
 
 	//check if an lcUser is present inside the context
 	var lcUser *api.LcUser
-	uif, err := api.GetUserFromContext(store.Config().CurrentContext, lcApiKey)
+	uif, err := api.GetUserFromContext(store.Config().CurrentContext, lcApiKey, lcLedger)
 	if err != nil {
 		return err
 	}
@@ -165,7 +169,7 @@ func runInspect(cmd *cobra.Command, args []string) error {
 
 	// use credentials if host is at least host is provided
 	if lcHost != "" && lcApiKey != "" {
-		lcUser, err = api.NewLcUser(lcApiKey, lcHost, lcPort, lcCert, skipTlsVerify, noTls)
+		lcUser, err = api.NewLcUser(lcApiKey, lcLedger, lcHost, lcPort, lcCert, skipTlsVerify, noTls)
 		if err != nil {
 			return err
 		} // Store the new config

--- a/pkg/cmd/login/lc_login.go
+++ b/pkg/cmd/login/lc_login.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/fatih/color"
 	vcnerr "github.com/vchain-us/vcn/internal/errors"
 	"github.com/vchain-us/vcn/pkg/api"
@@ -21,7 +22,7 @@ import (
 )
 
 // Execute the login action
-func ExecuteLC(host, port, lcCert, lcApiKey string, skipTlsVerify, lcNoTls bool) error {
+func ExecuteLC(host, port, lcCert, lcApiKey, lcLedger string, skipTlsVerify, lcNoTls bool) error {
 	if store.CNioContext() == true {
 		return errors.New("Already logged on CodeNotary.io. Please logout first.")
 	}
@@ -31,7 +32,7 @@ func ExecuteLC(host, port, lcCert, lcApiKey string, skipTlsVerify, lcNoTls bool)
 	color.Unset()
 
 	if lcApiKey != "" {
-		u, err := api.NewLcUser(lcApiKey, host, port, lcCert, skipTlsVerify, lcNoTls)
+		u, err := api.NewLcUser(lcApiKey, lcLedger, host, port, lcCert, skipTlsVerify, lcNoTls)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -11,6 +11,7 @@ package login
 import (
 	"errors"
 	"fmt"
+
 	"github.com/fatih/color"
 	"github.com/spf13/viper"
 
@@ -57,6 +58,7 @@ VCN_LC_CERT=
 VCN_LC_SKIP_TLS_VERIFY=false
 VCN_LC_NO_TLS=false
 VCN_LC_API_KEY=
+VCN_LC_LEDGER=
 `,
 		Example: `  # Codenotary.io login:
   ./vcn login
@@ -77,9 +79,10 @@ VCN_LC_API_KEY=
 			skipTlsVerify := viper.GetBool("lc-skip-tls-verify")
 			noTls := viper.GetBool("lc-no-tls")
 			lcApiKey := viper.GetString("lc-api-key")
+			lcLedger := viper.GetString("lc-ledger")
 
 			if lcHost != "" {
-				err = ExecuteLC(lcHost, lcPort, lcCert, lcApiKey, skipTlsVerify, noTls)
+				err = ExecuteLC(lcHost, lcPort, lcCert, lcApiKey, lcLedger, skipTlsVerify, noTls)
 				if err != nil {
 					return err
 				}
@@ -107,6 +110,7 @@ VCN_LC_API_KEY=
 	cmd.Flags().Bool("lc-skip-tls-verify", false, meta.VcnLcSkipTlsVerifyDesc)
 	cmd.Flags().Bool("lc-no-tls", false, meta.VcnLcNoTlsDesc)
 	cmd.Flags().String("lc-api-key", "", meta.VcnLcApiKeyDesc)
+	cmd.Flags().String("lc-ledger", "", meta.VcnLcLedgerDesc)
 
 	return cmd
 }

--- a/pkg/cmd/serve/credentials.go
+++ b/pkg/cmd/serve/credentials.go
@@ -34,5 +34,6 @@ func getCredential(r *http.Request) (user *api.User, passphrase string, err erro
 
 func getLcUser(r *http.Request, lcHost, lcPort, lcCert string, skipTlsVerify, noTls bool) (*api.LcUser, error) {
 	apikey := r.Header.Get("x-notarization-lc-api-key")
-	return api.NewLcUser(apikey, lcHost, lcPort, lcCert, skipTlsVerify, noTls)
+	ledger := r.Header.Get("x-notarization-lc-ledger")
+	return api.NewLcUser(apikey, ledger, lcHost, lcPort, lcCert, skipTlsVerify, noTls)
 }

--- a/pkg/cmd/sign/sign.go
+++ b/pkg/cmd/sign/sign.go
@@ -11,10 +11,11 @@ package sign
 import (
 	"bufio"
 	"fmt"
-	"github.com/spf13/viper"
-	"github.com/vchain-us/vcn/pkg/extractor/wildcard"
 	"os"
 	"strings"
+
+	"github.com/spf13/viper"
+	"github.com/vchain-us/vcn/pkg/extractor/wildcard"
 
 	"github.com/vchain-us/vcn/pkg/extractor/dir"
 
@@ -238,7 +239,7 @@ func runSignWithState(cmd *cobra.Command, args []string, state meta.Status) erro
 	//check if an lcUser is present inside the context
 	var lcUser *api.LcUser
 
-	uif, err := api.GetUserFromContext(store.Config().CurrentContext, lcApiKey)
+	uif, err := api.GetUserFromContext(store.Config().CurrentContext, lcApiKey, "")
 	if err != nil {
 		return err
 	}
@@ -248,7 +249,7 @@ func runSignWithState(cmd *cobra.Command, args []string, state meta.Status) erro
 
 	// use credentials if at least ledger compliance host is provided
 	if lcHost != "" && lcApiKey != "" {
-		lcUser, err = api.NewLcUser(lcApiKey, lcHost, lcPort, lcCert, skipTlsVerify, noTls)
+		lcUser, err = api.NewLcUser(lcApiKey, "", lcHost, lcPort, lcCert, skipTlsVerify, noTls)
 		if err != nil {
 			return err
 		} // Store the new config

--- a/pkg/cmd/verify/verify.go
+++ b/pkg/cmd/verify/verify.go
@@ -84,6 +84,7 @@ VCN_LC_CERT=
 VCN_LC_SKIP_TLS_VERIFY=false
 VCN_LC_NO_TLS=false
 VCN_LC_API_KEY=
+VCN_LC_LEDGER=
 `,
 		RunE: runVerify,
 		PreRun: func(cmd *cobra.Command, args []string) {
@@ -138,6 +139,7 @@ VCN_LC_API_KEY=
 	cmd.Flags().Bool("lc-skip-tls-verify", false, meta.VcnLcSkipTlsVerifyDesc)
 	cmd.Flags().Bool("lc-no-tls", false, meta.VcnLcNoTlsDesc)
 	cmd.Flags().String("lc-api-key", "", meta.VcnLcApiKeyDesc)
+	cmd.Flags().String("lc-ledger", "", meta.VcnLcLedgerDesc)
 
 	cmd.Flags().MarkHidden("raw-diff")
 
@@ -169,9 +171,10 @@ func runVerify(cmd *cobra.Command, args []string) error {
 	skipTlsVerify := viper.GetBool("lc-skip-tls-verify")
 	noTls := viper.GetBool("lc-no-tls")
 	lcApiKey := viper.GetString("lc-api-key")
+	lcLedger := viper.GetString("lc-ledger")
 	//check if an lcUser is present inside the context
 	var lcUser *api.LcUser
-	uif, err := api.GetUserFromContext(store.Config().CurrentContext, lcApiKey)
+	uif, err := api.GetUserFromContext(store.Config().CurrentContext, lcApiKey, lcLedger)
 	if err != nil {
 		return err
 	}
@@ -181,7 +184,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 
 	// use credentials if host is at least host is provided
 	if lcHost != "" && lcApiKey != "" {
-		lcUser, err = api.NewLcUser(lcApiKey, lcHost, lcPort, lcCert, skipTlsVerify, noTls)
+		lcUser, err = api.NewLcUser(lcApiKey, lcLedger, lcHost, lcPort, lcCert, skipTlsVerify, noTls)
 		if err != nil {
 			return err
 		}

--- a/pkg/meta/constants.go
+++ b/pkg/meta/constants.go
@@ -76,6 +76,7 @@ const VcnPrefix string = "vcn"
 
 // Ledger compliance
 const VcnLCPluginTypeHeaderName string = "lc-plugin-type"
+const VcnLCLedgerHeaderName string = "lc-ledger"
 const VcnLCPluginTypeHeaderValue string = "vcn"
 
 const VcnLcHostFlagDesc string = "if set with host, action will be route to a CodeNotary Ledger Compliance server"
@@ -84,6 +85,7 @@ const VcnLcCertPathDesc string = "local or absolute path to a certificate file n
 const VcnLcSkipTlsVerifyDesc string = "disables tls certificate verification when connecting to a CodeNotary Ledger Compliance server"
 const VcnLcNoTlsDesc string = "allow insecure connections when connecting to a CodeNotary Ledger Compliance server"
 const VcnLcApiKeyDesc string = "CodeNotary Ledger Compliance server api key"
+const VcnLcLedgerDesc string = "CodeNotary Ledger Compliance ledger. Required when a multi-ledger API key is used."
 const VcnLcAttachDesc string = "add user defined file attachments. Ex. vcn n myfile --attach mysecondfile. (repeat --attach for multiple entries). "
 
 // UserAgent returns the vcn's User-Agent string


### PR DESCRIPTION
Depends on [these Ledger Compliance Go SDK changes](https://github.com/vchain-us/ledger-compliance-go/pull/20)
and [these Ledger Compliance ones](https://github.com/vchain-us/ledger-compliance/pull/660).
Closes the [Multi-ledger read-only API keys issue](https://github.com/vchain-us/ledger-compliance/issues/657).