### PR TITLE
chore: update ledger-compliance-go dependency to fix missing metadata…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564
 	github.com/tyler-smith/go-bip39 v1.0.2
-	github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210401150401-454ef282b16a
+	github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210409124508-8386e9700009
 	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -442,6 +442,8 @@ github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210324153127-568e37041bef h
 github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210324153127-568e37041bef/go.mod h1:JSZUnkw1WnoUMPO0rDJksWiBd/zGixBw1FttXkEH34s=
 github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210401150401-454ef282b16a h1:SECrnb9kNvMy30Pt0P5A5izBkjRm4wNdLGcRME4vR50=
 github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210401150401-454ef282b16a/go.mod h1:s5+lEX16X8G8oAiUSuesBSvLx6zijhPU7I8BXHRDPlk=
+github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210409124508-8386e9700009 h1:25yiX9yO5kV1V+Dd1NkR9mBEXX3pqCD2ChQblhyxQxU=
+github.com/vchain-us/ledger-compliance-go v0.9.2-0.20210409124508-8386e9700009/go.mod h1:s5+lEX16X8G8oAiUSuesBSvLx6zijhPU7I8BXHRDPlk=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
… bug

This depends on [this LC Go SDK PR](https://github.com/vchain-us/ledger-compliance-go/pull/21).