### PR TITLE
chore: expose lc verify api and explicit environment vars

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -8,6 +8,14 @@
 
 package api
 
+import "fmt"
+
+// ErrNotVerified is returned when an artifact is not verified on CNLC
+var ErrNotVerified = fmt.Errorf("artifact is not verified")
+
+// ErrNotVerified is returned when an artifact is not found on CNLC
+var ErrNotFound = fmt.Errorf("artifact is not found")
+
 // Error represents a CodeNotary platform's API returned error.
 type Error struct {
 	Description string   `json:"description"`

--- a/pkg/api/lc_artifact.go
+++ b/pkg/api/lc_artifact.go
@@ -265,3 +265,14 @@ func (u *LcUser) DownloadAttachment(attach *Attachment, ar *LcArtifact, tx uint6
 
 	return ioutil.WriteFile(attach.Filename, attachEntry.Value, 0644)
 }
+
+// Date returns a RFC3339 formatted string of verification time (v.Timestamp), if any, otherwise an empty string.
+func (lca *LcArtifact) Date() string {
+	if lca != nil {
+		ut := lca.Timestamp.UTC()
+		if ut.Unix() > 0 {
+			return ut.Format(time.RFC3339)
+		}
+	}
+	return ""
+}

--- a/pkg/api/lc_user.go
+++ b/pkg/api/lc_user.go
@@ -25,6 +25,7 @@ type LcUser struct {
 }
 
 // NewUser returns a new User instance for the given email.
+// LcLedger parameter is used when a cross-ledger key is provided in order to specify the ledger on which future operations will be directed. Empty string is accepted
 func NewLcUser(lcApiKey, lcLedger, host, port, lcCert string, skipTlsVerify bool, noTls bool) (*LcUser, error) {
 	client, err := NewLcClient(lcApiKey, lcLedger, host, port, lcCert, skipTlsVerify, noTls)
 	if err != nil {

--- a/pkg/api/verify.go
+++ b/pkg/api/verify.go
@@ -229,7 +229,7 @@ func VerifyMatchingSignerIDs(hash string, signerIDs []string) (*BlockchainVerifi
 // PublicCNLCVerify allow connection and verification on CNLC ledger with a single call using environment variables.
 // LcLedger parameter is used when a cross-ledger key is provided in order to specify the ledger on which future operations will be directed. Empty string is accepted.
 // signerID parameter is used to filter result on a specific signer ID. If empty value is provided is used the current logged signerID value.
-func LcVerify(hash, lcLedger, signerID string) (a *LcArtifact, err error) {
+func LcVerifyEnv(hash, lcLedger, signerID string) (a *LcArtifact, err error) {
 	lcHost := os.Getenv(meta.VcnLcHost)
 	lcPort := os.Getenv(meta.VcnLcPort)
 	lcCert := os.Getenv(meta.VcnLcCert)
@@ -247,7 +247,7 @@ func PublicCNLCVerify(hash, lcLedger, signerID, lcHost, lcPort, lcCert string, l
 	}).Trace("LcVerify")
 
 	apiKey := os.Getenv(meta.VcnLcApiKey)
-	if apiKey != "" {
+	if apiKey == "" {
 		logs.LOG.Trace("Lc api key provided (environment)")
 		return nil, errors.ErrNoLcApiKeyEnv
 	}

--- a/pkg/api/verify.go
+++ b/pkg/api/verify.go
@@ -12,7 +12,11 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/vchain-us/vcn/internal/errors"
+	"github.com/vchain-us/vcn/internal/logs"
+
 	"math/big"
+	"os"
 	"strings"
 	"time"
 
@@ -220,4 +224,42 @@ func VerifyMatchingSignerIDs(hash string, signerIDs []string) (*BlockchainVerifi
 	return callVerifyFunc(func(instance *blockchain.AssetsRelay) (common.Address, *big.Int, *big.Int, *big.Int, error) {
 		return instance.VerifyAgainstPublishers(nil, hash, addresses)
 	})
+}
+
+// Verify returns the most recent *BlockchainVerification with highest level available for the given hash.
+func LcVerify(hash string) (a *LcArtifact, err error) {
+	logger().WithFields(logrus.Fields{
+		"hash": hash,
+	}).Trace("LcVerify")
+
+	apiKey := os.Getenv(meta.VcnLcApiKey)
+	if apiKey != "" {
+		logs.LOG.Trace("Lc api key provided (environment)")
+		return nil, errors.ErrNoLcApiKeyEnv
+	}
+	lcHost := os.Getenv(meta.VcnLcHost)
+	lcPort := os.Getenv(meta.VcnLcPort)
+	lcCert := os.Getenv(meta.VcnLcCert)
+	lcSkipTlsVerify := os.Getenv(meta.VcnLcSkipTlsVerify)
+	lcNoTls := os.Getenv(meta.VcnLcNoTls)
+
+	lcUser, err := NewLcUser(apiKey,"", lcHost, lcPort, lcCert, lcSkipTlsVerify == "true", lcNoTls == "true")
+	if err != nil {
+		return nil, err
+	}
+
+	err = lcUser.Client.Connect()
+	if err != nil {
+		return nil, err
+	}
+
+	if hash != "" {
+		a, _, err = lcUser.LoadArtifact(hash, "", 0)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return a, nil
+
 }

--- a/pkg/api/verify.go
+++ b/pkg/api/verify.go
@@ -252,10 +252,12 @@ func PublicCNLCVerify(hash, lcLedger, signerID, lcHost, lcPort, lcCert string, l
 		return nil, errors.ErrNoLcApiKeyEnv
 	}
 
-	lcUser, err := NewLcUser(apiKey, lcLedger, lcHost, lcPort, lcCert, lcSkipTlsVerify, lcNoTls)
+	client, err := NewLcClient(apiKey, lcLedger, lcHost, lcPort, lcCert, lcSkipTlsVerify, lcNoTls)
 	if err != nil {
 		return nil, err
 	}
+
+	lcUser := &LcUser{Client: client}
 
 	err = lcUser.Client.Connect()
 	if err != nil {
@@ -263,7 +265,7 @@ func PublicCNLCVerify(hash, lcLedger, signerID, lcHost, lcPort, lcCert string, l
 	}
 
 	if hash != "" {
-		a, _, err = lcUser.LoadArtifact(hash, "", 0)
+		a, _, err = lcUser.LoadArtifact(hash, signerID, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/serve/verify.go
+++ b/pkg/cmd/serve/verify.go
@@ -43,6 +43,10 @@ func (sh *handler) verify(w http.ResponseWriter, r *http.Request) {
 
 		ar, verified, err := lcUser.LoadArtifact(hash, "", 0)
 		if err != nil {
+			if err == api.ErrNotVerified {
+				writeError(w, http.StatusConflict, err)
+				return
+			}
 			writeError(w, http.StatusBadRequest, err)
 			return
 		}

--- a/pkg/cmd/sign/lc_sign.go
+++ b/pkg/cmd/sign/lc_sign.go
@@ -50,14 +50,14 @@ func LcSign(u *api.LcUser, artifacts []*api.Artifact, state meta.Status, output 
 			api.LcSignWithAttachments(attach),
 		)
 		if err != nil {
+			if err == api.ErrNotVerified {
+				color.Set(meta.StyleError())
+				fmt.Println("the ledger is compromised. Please contact the CodeNotary Ledger Compliance administrators")
+				color.Unset()
+				fmt.Println()
+				return nil
+			}
 			return err
-		}
-		if !verified {
-			color.Set(meta.StyleError())
-			fmt.Println("the ledger is compromised. Please contact the CodeNotary Ledger Compliance administrators")
-			color.Unset()
-			fmt.Println()
-			return nil
 		}
 
 		// writingManifest
@@ -77,16 +77,15 @@ func LcSign(u *api.LcUser, artifacts []*api.Artifact, state meta.Status, output 
 
 		artifact, verified, err := u.LoadArtifact(a.Hash, "", tx)
 		if err != nil {
+			if err == api.ErrNotVerified {
+				color.Set(meta.StyleError())
+				fmt.Println("the ledger is compromised. Please contact the CodeNotary Ledger Compliance administrators")
+				color.Unset()
+				fmt.Println()
+				artifact.Status = meta.StatusUnknown
+				return nil
+			}
 			return cli.PrintWarning(output, err.Error())
-		}
-
-		if !verified {
-			color.Set(meta.StyleError())
-			fmt.Println("the ledger is compromised. Please contact the CodeNotary Ledger Compliance administrators")
-			color.Unset()
-			fmt.Println()
-			artifact.Status = meta.StatusUnknown
-			return nil
 		}
 
 		if lenArtifacts > 1 && output == "" {

--- a/pkg/cmd/verify/hook.go
+++ b/pkg/cmd/verify/hook.go
@@ -106,7 +106,7 @@ func (h *hook) lcFinalizeWithoutAlert(user *api.LcUser, output string, txId uint
 			oldArtifact, _, err := user.LoadArtifact(oldDigest.Encoded(), "", txId)
 
 			if err != nil {
-				if status.Convert(err).Message() == "key not found" {
+				if err == api.ErrNotFound {
 					fmt.Printf("%s was not notarized", oldDigest.Encoded())
 				} else {
 					return err

--- a/pkg/cmd/verify/hook.go
+++ b/pkg/cmd/verify/hook.go
@@ -10,7 +10,6 @@ package verify
 
 import (
 	"fmt"
-	"google.golang.org/grpc/status"
 	"path/filepath"
 
 	"github.com/vchain-us/vcn/pkg/store"

--- a/pkg/meta/constants.go
+++ b/pkg/meta/constants.go
@@ -33,6 +33,7 @@ const (
 	LevelSocialVerified   Level = 2
 	LevelIDVerified       Level = 3
 	LevelLocationVerified Level = 4
+	LevelCNLC             Level = 98
 	LevelVchain           Level = 99
 )
 

--- a/pkg/meta/constants.go
+++ b/pkg/meta/constants.go
@@ -68,6 +68,11 @@ const (
 	VcnOtp                       string = "VCN_OTP"
 	VcnOtpEmpty                  string = "VCN_OTP_EMPTY"
 	VcnLcApiKey                  string = "VCN_LC_API_KEY"
+	VcnLcHost                    string = "VCN_LC_HOST"
+	VcnLcPort                    string = "VCN_LC_PORT"
+	VcnLcCert                    string = "VCN_LC_CERT"
+	VcnLcNoTls                   string = "VCN_LC_NO_TLS"
+	VcnLcSkipTlsVerify           string = "VCN_LC_SKIP_TLS_VERIFY"
 )
 
 const VcnExitCode string = "override default exit codes in case of success"


### PR DESCRIPTION
add up-to-date kube-notary support 