### PR TITLE
chore(cmd/verify): if api-key is revoked status will be shown as revo…

### DIFF
--- a/pkg/cmd/verify/lc_verify.go
+++ b/pkg/cmd/verify/lc_verify.go
@@ -36,7 +36,9 @@ func lcVerify(cmd *cobra.Command, a *api.Artifact, user *api.LcUser, signerID st
 	}
 	if ar.Revoked != nil && !ar.Revoked.IsZero() {
 		viper.Set("exit-code", strconv.Itoa(meta.StatusApikeyRevoked.Int()))
+		ar.Status = meta.StatusApikeyRevoked
 	}
+
 	if output == "attachments" {
 		color.Set(meta.StyleAffordance())
 		fmt.Println("downloading attachments ...")

--- a/pkg/meta/constants.go
+++ b/pkg/meta/constants.go
@@ -136,6 +136,8 @@ func (s Status) String() string {
 		return "UNKNOWN"
 	case StatusUnsupported:
 		return "UNSUPPORTED"
+	case StatusApikeyRevoked:
+		return "REVOKED"
 	default:
 		log.Fatal("unsupported status: ", int64(s))
 		return ""

--- a/pkg/meta/styles.go
+++ b/pkg/meta/styles.go
@@ -19,6 +19,8 @@ func StatusColor(status Status) (color.Attribute, color.Attribute, color.Attribu
 		return StyleSuccess()
 	case StatusUnknown:
 		return StyleWarning()
+	case StatusApikeyRevoked:
+		return StyleWarning()
 	default:
 		return StyleError()
 	}


### PR DESCRIPTION
if api-key is revoked status will be shown as revoked in authenticate