### PR TITLE
feat(pkg/api): lc artifact contains uid

### DIFF
--- a/pkg/api/lc_artifact.go
+++ b/pkg/api/lc_artifact.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"time"
 
 	immuschema "github.com/codenotary/immudb/pkg/api/schema"
@@ -48,7 +49,9 @@ func ItemToLcArtifact(item *schema.ItemExt) (*LcArtifact, error) {
 	if err != nil {
 		return nil, err
 	}
-	lca.Timestamp = time.Unix(int64(item.Timestamp.GetSeconds()), int64(item.Timestamp.GetNanos())).UTC()
+	ts := time.Unix(item.Timestamp.GetSeconds(), int64(item.Timestamp.GetNanos()))
+	lca.Uid = strconv.Itoa(int(ts.UnixNano()))
+	lca.Timestamp = ts.UTC()
 	// if ApikeyRevoked == nil no revoked infos available. Old key type
 	if item.ApikeyRevoked != nil {
 		if item.ApikeyRevoked.GetSeconds() > 0 {
@@ -67,7 +70,9 @@ func ZItemToLcArtifact(ie *schema.ZItemExt) (*LcArtifact, error) {
 	if err != nil {
 		return nil, err
 	}
-	lca.Timestamp = time.Unix(int64(ie.Timestamp.GetSeconds()), int64(ie.Timestamp.GetNanos())).UTC()
+	ts := time.Unix(ie.Timestamp.GetSeconds(), int64(ie.Timestamp.GetNanos()))
+	lca.Uid = strconv.Itoa(int(ts.UnixNano()))
+	lca.Timestamp = ts.UTC()
 	// if ApikeyRevoked == nil no revoked infos available. Old key type
 	if ie.ApikeyRevoked != nil {
 		if ie.ApikeyRevoked.GetSeconds() > 0 {
@@ -86,7 +91,9 @@ func VerifiableItemExtToLcArtifact(item *schema.VerifiableItemExt) (*LcArtifact,
 	if err != nil {
 		return nil, err
 	}
-	lca.Timestamp = time.Unix(int64(item.Timestamp.GetSeconds()), int64(item.Timestamp.GetNanos())).UTC()
+	ts := time.Unix(item.Timestamp.GetSeconds(), int64(item.Timestamp.GetNanos()))
+	lca.Uid = strconv.Itoa(int(ts.UnixNano()))
+	lca.Timestamp = ts.UTC()
 	// if ApikeyRevoked == nil no revoked infos available. Old key type
 	if item.ApikeyRevoked != nil {
 		if item.ApikeyRevoked.GetSeconds() > 0 {
@@ -101,6 +108,7 @@ func VerifiableItemExtToLcArtifact(item *schema.VerifiableItemExt) (*LcArtifact,
 
 type LcArtifact struct {
 	// root fields
+	Uid         string    `json:"uid" yaml:"uid" vcn:"uid"`
 	Kind        string    `json:"kind" yaml:"kind" vcn:"Kind"`
 	Name        string    `json:"name" yaml:"name" vcn:"Name"`
 	Hash        string    `json:"hash" yaml:"hash" vcn:"Hash"`

--- a/pkg/api/verify.go
+++ b/pkg/api/verify.go
@@ -265,7 +265,7 @@ func PublicCNLCVerify(hash, lcLedger, signerID, lcHost, lcPort, lcCert string, l
 	}
 
 	if hash != "" {
-		a, _, err = lcUser.LoadArtifact(hash, signerID, 0)
+		a, _, err = lcUser.LoadArtifact(hash, signerID, "", 0)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/serve/lc_sign.go
+++ b/pkg/cmd/serve/lc_sign.go
@@ -68,7 +68,7 @@ func lcSign(user *api.LcUser, status meta.Status, kinds map[string]bool, w http.
 		return
 	}
 
-	ar, verified, err := user.LoadArtifact(artifact.Hash, "", tx)
+	ar, verified, err := user.LoadArtifact(artifact.Hash, "", "", tx)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return

--- a/pkg/cmd/serve/verify.go
+++ b/pkg/cmd/serve/verify.go
@@ -41,7 +41,7 @@ func (sh *handler) verify(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		ar, verified, err := lcUser.LoadArtifact(hash, "", 0)
+		ar, verified, err := lcUser.LoadArtifact(hash, "", "", 0)
 		if err != nil {
 			if err == api.ErrNotVerified {
 				writeError(w, http.StatusConflict, err)

--- a/pkg/cmd/sign/lc_sign.go
+++ b/pkg/cmd/sign/lc_sign.go
@@ -75,7 +75,7 @@ func LcSign(u *api.LcUser, artifacts []*api.Artifact, state meta.Status, output 
 			fmt.Println()
 		}
 
-		artifact, verified, err := u.LoadArtifact(a.Hash, "", tx)
+		artifact, verified, err := u.LoadArtifact(a.Hash, "", "", tx)
 		if err != nil {
 			if err == api.ErrNotVerified {
 				color.Set(meta.StyleError())

--- a/pkg/cmd/sign/sign.go
+++ b/pkg/cmd/sign/sign.go
@@ -278,7 +278,7 @@ func runSignWithState(cmd *cobra.Command, args []string, state meta.Status) erro
 		if hash != "" {
 			hash = strings.ToLower(hash)
 			// Load existing artifact, if any, otherwise use an empty artifact
-			if ar, _, err := lcUser.LoadArtifact(hash, "", 0); err == nil && ar != nil {
+			if ar, _, err := lcUser.LoadArtifact(hash, "", "", 0); err == nil && ar != nil {
 				artifacts = []*api.Artifact{{
 					Kind:        ar.Kind,
 					Name:        ar.Name,

--- a/pkg/cmd/verify/hook.go
+++ b/pkg/cmd/verify/hook.go
@@ -102,7 +102,7 @@ func (h *hook) lcFinalizeWithoutAlert(user *api.LcUser, output string, txId uint
 				fmt.Printf("Diff is unavailable because '%s' is invalid.\n\n", bundle.ManifestFilename)
 				return nil // ignore bad manifest
 			}
-			oldArtifact, _, err := user.LoadArtifact(oldDigest.Encoded(), "", txId)
+			oldArtifact, _, err := user.LoadArtifact(oldDigest.Encoded(), "", "", txId)
 
 			if err != nil {
 				if err == api.ErrNotFound {

--- a/pkg/cmd/verify/lc_verify.go
+++ b/pkg/cmd/verify/lc_verify.go
@@ -13,13 +13,13 @@ import (
 	"strconv"
 )
 
-func lcVerify(cmd *cobra.Command, a *api.Artifact, user *api.LcUser, signerID string, output string) (err error) {
+func lcVerify(cmd *cobra.Command, a *api.Artifact, user *api.LcUser, signerID string, uid string, output string) (err error) {
 	hook := newHook(cmd, a)
 	err = hook.lcFinalizeWithoutAlert(user, output, 0)
 	if err != nil {
 		return err
 	}
-	ar, verified, err := user.LoadArtifact(a.Hash, signerID, 0)
+	ar, verified, err := user.LoadArtifact(a.Hash, signerID, uid, 0)
 	if err != nil {
 		if err == api.ErrNotFound {
 			err = fmt.Errorf("%s was not notarized", a.Hash)

--- a/pkg/cmd/verify/verify.go
+++ b/pkg/cmd/verify/verify.go
@@ -140,6 +140,7 @@ VCN_LC_LEDGER=
 	cmd.Flags().Bool("lc-no-tls", false, meta.VcnLcNoTlsDesc)
 	cmd.Flags().String("lc-api-key", "", meta.VcnLcApiKeyDesc)
 	cmd.Flags().String("lc-ledger", "", meta.VcnLcLedgerDesc)
+	cmd.Flags().String("lc-uid", "", meta.VcnLcUidDesc)
 
 	cmd.Flags().MarkHidden("raw-diff")
 
@@ -172,6 +173,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 	noTls := viper.GetBool("lc-no-tls")
 	lcApiKey := viper.GetString("lc-api-key")
 	lcLedger := viper.GetString("lc-ledger")
+	lcUid := viper.GetString("lc-uid")
 	//check if an lcUser is present inside the context
 	var lcUser *api.LcUser
 	uif, err := api.GetUserFromContext(store.Config().CurrentContext, lcApiKey, lcLedger)
@@ -209,7 +211,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 			a := &api.Artifact{
 				Hash: strings.ToLower(hash),
 			}
-			return lcVerify(cmd, a, lcUser, signerID, output)
+			return lcVerify(cmd, a, lcUser, signerID, lcUid, output)
 		}
 
 		artifacts, err := extractor.Extract([]string{args[0]})
@@ -217,7 +219,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		for _, a := range artifacts {
-			err := lcVerify(cmd, a, lcUser, signerID, output)
+			err := lcVerify(cmd, a, lcUser, signerID, lcUid, output)
 			if err != nil {
 				return err
 			}

--- a/pkg/meta/constants.go
+++ b/pkg/meta/constants.go
@@ -95,6 +95,7 @@ const VcnLcApiKeyDesc string = "CodeNotary Ledger Compliance server api key"
 const VcnLcLedgerDesc string = "CodeNotary Ledger Compliance ledger. Required when a multi-ledger API key is used."
 const VcnLcAttachDesc string = "add user defined file attachments. Ex. vcn n myfile --attach mysecondfile. (repeat --attach for multiple entries). "
 const VcnLcCIAttribDesc string = "detect CI environment variables context if presents and inject "
+const VcnLcUidDesc string = "authenticate on a specific artifact uid"
 
 // UserAgent returns the vcn's User-Agent string
 func UserAgent() string {


### PR DESCRIPTION
THis PR add the  capability to `vcn a` command to specify an artifact id (--lc-uid flag) on which authenticate.
It's useful for example to download old attachments:

`vcn a .gitignore --lc-uid=1619726586689527916 --output=attachments`