### PR TITLE
Fix crash with wrong notarization password

### DIFF
--- a/pkg/api/sign.go
+++ b/pkg/api/sign.go
@@ -71,15 +71,14 @@ func (u User) Sign(artifact Artifact, options ...SignOption) (*BlockchainVerific
 	// This is a workaround. Need a proper solution to handle parallel signing
 	var verification *BlockchainVerification
 	for i := uint64(0); i < meta.TxVerificationRounds(); i++ {
-		verification, err = u.commitTransaction(artifact, options...)
+		verification, err := u.commitTransaction(artifact, options...)
 		if err != nil {
-			if err.Error() == errors.BlockchainPermission {
+			if err.Error() == errors.BlockchainPermission || strings.Contains(err.Error(), "method <sign> failed") {
 				rand.Seed(time.Now().UnixNano())
 				sleepTime := time.Second * time.Duration(int64(rand.Intn(6)))
 				time.Sleep(sleepTime)
 				continue
 			}
-			break
 		}
 		return verification, err
 	}

--- a/pkg/api/sign.go
+++ b/pkg/api/sign.go
@@ -71,7 +71,7 @@ func (u User) Sign(artifact Artifact, options ...SignOption) (*BlockchainVerific
 	// This is a workaround. Need a proper solution to handle parallel signing
 	var verification *BlockchainVerification
 	for i := uint64(0); i < meta.TxVerificationRounds(); i++ {
-		verification, err := u.commitTransaction(artifact, options...)
+		verification, err = u.commitTransaction(artifact, options...)
 		if err != nil {
 			if err.Error() == errors.BlockchainPermission {
 				rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
If the notarization password was wrong, or any other error not in being a `errors.BlockchainPermission` ended in the break case.

```go
if err != nil {
	if err.Error() == errors.BlockchainPermission {
		rand.Seed(time.Now().UnixNano())
		sleepTime := time.Second * time.Duration(int64(rand.Intn(6)))
		time.Sleep(sleepTime)
		continue
	}
	break
}
```

Because of an extra colon, a new scope was created. The break ended returning the verification and the error from outside of the for, which was nil.

```go
verification, err := u.commitTransaction(artifact, options...)
```

Because the error was nil, the calling code attempted to display the verification, which because of the error, was nil, resulting in a crash.

# How to reproduce

```
export VCN_USER=youruser@domain.com
export VCN_PASSWORD=foobar
export VCN_NOTARIZATION_PASSWORD=${VCN_PASSWORD}xxwrongxxx

vcn login
vcn n file
```

Would result in a crash.

With this PR it would display the appropriate error.