### PR TITLE
fix: Make test file content unique to avoid parallel notarization

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
           export PATH=$PATH:${GITHUB_WORKSPACE}/bin
           export VCN_OTP_EMPTY=1
 
-          echo "This is some content" > README.txt
+          echo "This is some content generated in ${GITHUB_ACTION}, ${GITHUB_JOB}, ${GITHUB_RUN_NUMBER}, ${GITHUB_SHA} on ${{ matrix.os }}-${{ matrix.go }}" > README.txt
           echo "This is some other content" > UNKNOWN.txt
 
           ${{ matrix.exe }} login


### PR DESCRIPTION
Make the content of the file notarized in the integration test unique to avoid parallel notarization.

We still need to test those, but it should not be by accident in the base case, but explicitly using machma in its own testcase.