### PR TITLE
chore(pkg/api): handle parallel request with same hash on blockchain

### DIFF
--- a/internal/errors/messages.go
+++ b/internal/errors/messages.go
@@ -54,4 +54,8 @@ Please try again later. If the problem persists contact our support.`
 
 const SignFailed = `method <sign> failed`
 
+const BlockchainSameHashAlreadyImported = `transaction with the same hash was already imported`
+
+const BlockchainTxNonceTooLow = `transaction nonce is too low. Try incrementing the nonce`
+
 var ErrNoLcApiKeyEnv = errors.New(`no API key configured. Please set the environment variable VCN_LC_API_KEY=<API-KEY> or use --lc-api-key flag on each request before running any commands`)

--- a/pkg/cmd/sign/sign.go
+++ b/pkg/cmd/sign/sign.go
@@ -448,8 +448,10 @@ func sign(u api.User, a api.Artifact, state meta.Status, visibility meta.Visibil
 
 	cli.Print(output, types.NewResult(&a, artifact, verification))
 
-	if err := handleAlert(alert, u, a, *verification, output); err != nil {
-		return cli.PrintWarning(output, err.Error())
+	if alert != nil {
+		if err := handleAlert(alert, u, a, *verification, output); err != nil {
+			return cli.PrintWarning(output, err.Error())
+		}
 	}
 
 	return nil

--- a/pkg/cmd/sign/sign_integration_test.go
+++ b/pkg/cmd/sign/sign_integration_test.go
@@ -51,14 +51,14 @@ func TestParallelNotarization(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		a, _ := extractor.Extract("file://../../../CONTRIBUTING.md")
+		a, _ := extractor.Extract([]string{"file://../../../CONTRIBUTING.md"})
 		_, err := psign(user, a, userPw)
 		assert.NoError(t, err)
 		wg.Done()
 	}()
 	wg.Add(1)
 	go func() {
-		a, _ := extractor.Extract("file://../../../README.md")
+		a, _ := extractor.Extract([]string{"file://../../../README.md"})
 		_, err := psign(user, a, userPw)
 		assert.NoError(t, err)
 		wg.Done()
@@ -66,7 +66,7 @@ func TestParallelNotarization(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		a, _ := extractor.Extract("file://../../../LICENSE")
+		a, _ := extractor.Extract([]string{"file://../../../LICENSE"})
 		_, err := psign(user, a, userPw)
 		assert.NoError(t, err)
 		wg.Done()
@@ -74,7 +74,7 @@ func TestParallelNotarization(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		a, _ := extractor.Extract("file://../../../go.mod")
+		a, _ := extractor.Extract([]string{"file://../../../go.mod"})
 		_, err := psign(user, a, userPw)
 		assert.NoError(t, err)
 		wg.Done()
@@ -82,11 +82,115 @@ func TestParallelNotarization(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		a, _ := extractor.Extract("file://../../../Makefile")
+		a, _ := extractor.Extract([]string{"file://../../../Makefile"})
 		_, err := psign(user, a, userPw)
 		assert.NoError(t, err)
 		wg.Done()
 	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../go.mod"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../go.sum"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../Dockerfile"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../Dockerfile.docker"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../CONTRIBUTING.md"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../README.md"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../LICENSE"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../go.mod"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../Makefile"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../go.mod"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../go.sum"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../Dockerfile"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a, _ := extractor.Extract([]string{"file://../../../Dockerfile.docker"})
+		_, err := psign(user, a, userPw)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
 	wg.Wait()
 	fmt.Println("done")
 }


### PR DESCRIPTION
Here is added a more granular control on error triggered when 2+ transactions with same hash are submitted to blockchain